### PR TITLE
Add z-0 to main container

### DIFF
--- a/resources/views/compare.blade.php
+++ b/resources/views/compare.blade.php
@@ -7,7 +7,7 @@
     <div class="container">
         <h1 class="mb-5 text-3xl font-bold">@lang('Compare')</h1>
         <product-compare v-slot="compare" v-cloak>
-            <div class="relative text-sm">
+            <div class="relative text-sm z-0">
                 <template v-if="compare?.items?.length">
                     <div class="absolute left-0 top-0 bottom-5 w-1/2 sm:w-1/3 lg:w-1/4 xl:w-1/5 bg-white z-10 max-sm:hidden"></div>
                     <slider container-reference="container">


### PR DESCRIPTION
This makes it so the buttons and such don't go over top of slideovers and megamenus